### PR TITLE
Add openSUSE distro cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ exports.name = function(cb) {
 
   var done = function(err, name) {
     if (err) return cb(err);
+    if (name.toString().indexOf('openSUSE') != -1) name = 'Opensuse';
 
     cb(null, name.toString().replace(' Linux', ''));
   }


### PR DESCRIPTION
Make sure that all openSUSE distro name variations are included so the Prey agent recognise it.